### PR TITLE
Remove duplicate for Houzz

### DIFF
--- a/data.json
+++ b/data.json
@@ -265,11 +265,6 @@
     "errorType": "message",
     "errorMsg": "The page you requested was not found."
   },
-  "Houzz": {
-    "url": "https://houzz.com/user/{}",
-    "errorType": "message",
-    "errorMsg": "The page you requested was not found."
-  },
   "BLIP.fm": {
     "url": "https://blip.fm/{}",
     "errorType": "message",


### PR DESCRIPTION
There were two entries for https://houzz.com/user. Must have been a cut-and-paste error.